### PR TITLE
fixes bare_variables ansible deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     create: true
     dest: "{{ item }}"
     line: 'session required pam_limits.so'
-  with_items: limits_pam_files
+  with_items: "{{ limits_pam_files }}"
   tags: [configuration, limits, limits-pam]
 
 - name: update configuration file(s)
@@ -15,5 +15,5 @@
     owner: root
     group: root
     mode: 0644
-  with_dict: limits_conf_d_files
+  with_dict: "{{ limits_conf_d_files }}"
   tags: [configuration, limits, limits-configuration]


### PR DESCRIPTION
With Ansible 2 I see warnings due to bare variables:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses 
the full variable syntax ('{{limits_pam_files}}'). This feature will be removed in a future release. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This changes quotes the variables.
I have also tested this change in a separate playbook of mine.
