### PR TITLE
Optionally mess with pam_limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 # defaults file for limits
 ---
 limits_conf_d_files: {}
+limits_enforce_pam_limits: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 # defaults file for limits
 ---
 limits_conf_d_files: {}
-limits_enforce_pam_limits: true
+limits_pam_files:
+  - /etc/pam.d/common-session
+  - /etc/pam.d/common-session-noninteractive

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     dest: "{{ item }}"
     line: 'session required pam_limits.so'
   with_items: "{{ limits_pam_files }}"
+  when: limits_enforce_pam_limits
   tags: [configuration, limits, limits-pam]
 
 - name: update configuration file(s)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,6 @@
     dest: "{{ item }}"
     line: 'session required pam_limits.so'
   with_items: "{{ limits_pam_files }}"
-  when: limits_enforce_pam_limits
   tags: [configuration, limits, limits-pam]
 
 - name: update configuration file(s)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,0 @@
-# vars file for limits
----
-limits_pam_files:
-  - /etc/pam.d/common-session
-  - /etc/pam.d/common-session-noninteractive


### PR DESCRIPTION
Hi there!
I'm using this role to configure limits on my CentOS servers.
And by default pam_limits are already configured on CentOS.
So I've added possibility not to mess with any pam_limits.

P.S. I wonder why haven't you proposed your changes to upstream? It's kinda strange to open PR to fork.
